### PR TITLE
Add dependency rspec and pry

### DIFF
--- a/rspec-daemon.gemspec
+++ b/rspec-daemon.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "rspec"
+  spec.add_dependency "pry"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
hi @asonas

When I was younger, I could just hit the keyboard enough to run rspec by myself! I thought,
You realize there's a limit to how many times a person can hit the keyboard.

I've been using Guard since I hurt my wrist and fingers with tendonitis,
It's slow and I don't think I've been doing it lately.

rspec-daemon sounds good!

I'm sending you a PR because I had a little problem with the initial installation.
I got the following problems, but this change should fix them.

Have a nice holiday!

```
$ bundle exec rspec-daemon spec
bundler: failed to load command: rspec-daemon (/Users/koheisg/.rbenv/versions/3.2.2/bin/rspec-daemon)
<internal:/Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- pry (LoadError)
Did you mean?  pty
        from <internal:/Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/lib/rspec/daemon.rb:9:in `<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/lib/rspec/daemon/cli.rb:1:in `require_relative'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/lib/rspec/daemon/cli.rb:1:in `<top (required)>'
        from <internal:/Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/exe/rspec-daemon:3:in `<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/bin/rspec-daemon:25:in `load'
        from /Users/koheisg/.rbenv/versions/3.2.2/bin/rspec-daemon:25:in `<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:492:in `exec'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:45:in `block in <top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:33:in `<top (required)>'
        from /Users/koheisg/my-rails-project/bin/bundle:113:in `load'
        from /Users/koheisg/my-rails-project/bin/bundle:113:in `<main>'
```

```
$ bundle exec rspec-daemon
bundler: failed to load command: rspec-daemon (/Users/koheisg/.rbenv/versions/3.2.2/bin/rspec-daemon)
/Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/lib/rspec/daemon.rb:8:in `require': cannot load such file -- rspec (LoadError)
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/lib/rspec/daemon.rb:8:in `<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/lib/rspec/daemon/cli.rb:1:in `require_relative'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/lib/rspec/daemon/cli.rb:1:in `<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/exe/rspec-daemon:3:in `require'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-daemon-0.1.2/exe/rspec-daemon:3:in `<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/bin/rspec-daemon:25:in `load'
        from /Users/koheisg/.rbenv/versions/3.2.2/bin/rspec-daemon:25:in `<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `load'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `kernel_load'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:23:in `run'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/cli.rb:486:in `exec'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/cli.rb:31:in `dispatch'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/cli.rb:25:in `start'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/exe/bundle:48:in `block in <top (required)>'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
        from /Users/koheisg/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.26/exe/bundle:36:in `<top (required)>'
        from /Users/koheisg/my-rails-project/bin/bundle:113:in `load'
        from /Users/koheisg/my-rails-project/bin/bundle:113:in `<main>'
```