### PR TITLE
feat: allow configuration of port via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $ bundle ex rspec-daemon
 $ echo 'spec/models/user_spec.rb' | nc -v 0.0.0.0 3002
 ```
 
+By default, `rspec-daemon` will run on port `3002`. You can adjust the port by setting the `RSPEC_DAEMON_PORT` environment variable.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/rspec/daemon.rb
+++ b/lib/rspec/daemon.rb
@@ -11,6 +11,7 @@ require "pry"
 module RSpec
   class Daemon
     SCRIPT_NAME = File.basename(__FILE__).freeze
+    RSPEC_DAEMON_DEFAULT_PORT = 3002
 
     class Error < StandardError; end
 
@@ -26,8 +27,8 @@ module RSpec
       $LOAD_PATH << "./spec"
 
       RSpec::Core::Runner.disable_autorun!
-      server = TCPServer.open("0.0.0.0", 3002)
-      puts "start tcp server"
+      server = TCPServer.open("0.0.0.0", ENV.fetch("RSPEC_DAEMON_PORT", RSPEC_DAEMON_DEFAULT_PORT))
+      puts "Listening on port #{server.addr[1]}"
 
       loop do
         handle_request(server.accept)


### PR DESCRIPTION
Hi, just added a way to configure the port using the `RSPEC_DAEMON_PORT` (see issue #2 ). By default, 3002 is still being used.