### PR TITLE
Remove pry dependency

### DIFF
--- a/lib/rspec/daemon.rb
+++ b/lib/rspec/daemon.rb
@@ -6,7 +6,6 @@ require_relative "daemon/configuration"
 require "socket"
 require "stringio"
 require "rspec"
-require "pry"
 
 module RSpec
   class Daemon

--- a/rspec-daemon.gemspec
+++ b/rspec-daemon.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "rspec"
-  spec.add_dependency "pry"
+  spec.add_development_dependency "pry"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
While Pry is useful for development, rspec-daemon users should not be required to install pry, so change pry to a development dependency.