### PR TITLE
Make bind address and port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ gem 'rspec-daemon', require: false
 ```
 $ cd YOUR_PROJECT
 $ bundle ex rspec-daemon
+Listening on tcp://0.0.0.0:3002
 ```
 
 ```
 $ echo 'spec/models/user_spec.rb' | nc -v 0.0.0.0 3002
 ```
 
-By default, `rspec-daemon` will run on port `3002`. You can adjust the port by setting the `RSPEC_DAEMON_PORT` environment variable.
+By default, `rspec-daemon` will run on port `3002`. You can adjust the port by passing `--port` to `rspec-daemon` or setting the `RSPEC_DAEMON_PORT` environment variable.
 
 ## Development
 

--- a/exe/rspec-daemon
+++ b/exe/rspec-daemon
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 require 'rspec/daemon/cli'
-RSpec::Daemon::Cli.start
+RSpec::Daemon::Cli.start(ARGV)

--- a/lib/rspec/daemon.rb
+++ b/lib/rspec/daemon.rb
@@ -10,24 +10,20 @@ require "rspec"
 module RSpec
   class Daemon
     SCRIPT_NAME = File.basename(__FILE__).freeze
-    RSPEC_DAEMON_DEFAULT_PORT = 3002
 
     class Error < StandardError; end
 
-    def self.start
-      self.new.start
+    def initialize(bind_address, port)
+      @bind_address = bind_address
+      @port = port
     end
 
     def start
-      entry_point
-    end
-
-    def entry_point
       $LOAD_PATH << "./spec"
 
       RSpec::Core::Runner.disable_autorun!
-      server = TCPServer.open("0.0.0.0", ENV.fetch("RSPEC_DAEMON_PORT", RSPEC_DAEMON_DEFAULT_PORT))
-      puts "Listening on port #{server.addr[1]}"
+      server = TCPServer.open(@bind_address, @port)
+      puts "Listening on tcp://#{server.addr[2]}:#{server.addr[1]}"
 
       loop do
         handle_request(server.accept)

--- a/lib/rspec/daemon/cli.rb
+++ b/lib/rspec/daemon/cli.rb
@@ -3,8 +3,42 @@ require_relative '../daemon'
 module RSpec
   class Daemon
     class Cli
-      def self.start
-        RSpec::Daemon.start
+      DEFAULT_OPTIONS = {
+        bind_address: "0.0.0.0",
+        port: 3002,
+      }
+
+      def self.start(...)
+        new.start(...)
+      end
+
+      def start(argv)
+        options = DEFAULT_OPTIONS.dup
+        if ENV['RSPEC_DAEMON_BIND_ADDRESS']
+          options[:bind_address] = ENV['RSPEC_DAEMON_BIND_ADDRESS']
+        end
+        if ENV['RSPEC_DAEMON_PORT']
+          options[:port] = ENV['RSPEC_DAEMON_PORT'].to_i
+        end
+
+        option_parser = OptionParser.new do |opts|
+          opts.on('-v', '--version', 'Prints version') do
+            puts RSpec::Daemon::VERSION
+            exit
+          end
+
+          opts.on('-b', '--bind ADDRESS', 'address to bind (default: 0.0.0.0)') do |address|
+            options[:bind_address] = address
+          end
+
+          opts.on('-p', '--port PORT', 'port to listen on (default: 3002)') do |port|
+            options[:port] = port
+          end
+        end
+        option_parser.parse!(argv)
+
+        RSpec::Daemon.new(options[:bind_address], options[:port]).start
+        0
       end
     end
   end


### PR DESCRIPTION
rspec-daemon users would want to use ports other than 3002.

Sidenote: rspec-daemon binds to 0.0.0.0 (all addresses) by default, but this might be considered unnecessarily open and insecure. I believe 127.0.0.1 is a better option, as typical rspec-daemon usage probably won't involve external access.

I haven't changed any defaults here.