### PR TITLE
Add information about editor integration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,57 @@ $ bundle ex rspec-daemon
 $ echo 'spec/models/user_spec.rb' | nc -v 0.0.0.0 3002
 ```
 
+## Editor integration
+
+### Vim/Neovim
+
+Add a key binding of your preference to your `.vimrc` or `init.vim`.
+
+```vim
+" Run specs under the current cursor line
+nnoremap <Leader>h :execute '!bundle exec rspeccc ' . expand('%:p') . ':' . line('.')<CR>
+```
+
+If you are using [rspec.vim](https://github.com/thoughtbot/vim-rspec), you may want to configure `g:rspec_command`.
+
+```vim
+" For rspec.vim users
+let g:rspec_command = "!bundle exec rspeccc {spec}"
+```
+
+### Visual Studio Code
+
+Tasks are a nice way to launch `rspeccc`.
+Here is an example `tasks.json` configuration which runs specs under the current cursor location:
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "rspec-remote: Cursor context",
+      "group": "test",
+      "type": "shell",
+      "command": "bundle exec rspeccc ${relativeFile}:${lineNumber}"
+    }
+  ]
+}
+```
+
+Adding a keybindings.json entry for your Task is also recommendable.
+
+```json
+[
+  {
+    "key": "cmd+h",
+    "command": "workbench.action.tasks.runTask",
+    "args": "rspec-remote: Cursor context"
+  }
+]
+```
+
+Refer to Visual Studio Code's documentation ([Integrate with External Tools via Tasks](https://go.microsoft.com/fwlink/?LinkId=733558)) for further customization.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.


### PR DESCRIPTION
I've added information about integrating rspec-daemon with Vim, Neovim and Visual Studio Code. Should only be merged after #5.