### PR TITLE
Fix the method to start the test

### DIFF
--- a/exe/rspeccc
+++ b/exe/rspeccc
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 require 'rspec/daemon/client_cli'
-exit RSpec::Daemon::ClientCli.run(ARGV)
+exit RSpec::Daemon::ClientCli.start(ARGV)


### PR DESCRIPTION
The following error occurred when executing the `rspeccc` command in v1.0.0 .

> undefined method `run' for RSpec::Daemon::ClientCli:Class (NoMethodError)

This PR makes a change to use the `.start` method to start the test.