### PR TITLE
Rails: Invoke autoreloading on every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ $ echo 'spec/models/user_spec.rb' | nc -v 0.0.0.0 3002
 
 By default, `rspec-daemon` will run on port `3002`. You can adjust the port by passing `--port` to `rspec-daemon` or setting the `RSPEC_DAEMON_PORT` environment variable.
 
+### Auto-reloading application code in Rails
+
+If properly configured, rspec-daemon will automatically reload your application code (you probably want this behavior).
+Add the following code to `config/initializers/rspec_daemon.rb`:
+
+```ruby
+# rspec-daemon exposes RSPEC_DAEMON=1
+if Rails.env.test? && ENV['RSPEC_DAEMON']
+  Rails.configuration.enable_reloading = true
+end
+```
+
+If autoreloading is not configured, you'd need to restart `rspec-daemon` every time you change code under `app/`.
+Spec code (under `spec/`) will be always reloaded regardless of this setting.
+
 ## Editor integration
 
 ### Vim/Neovim

--- a/lib/rspec/daemon.rb
+++ b/lib/rspec/daemon.rb
@@ -64,8 +64,15 @@ module RSpec
       RSpec.reset
 
       if cached_config.has_recorded_config?
+        # Reload configuration from the first time
         cached_config.replay_configuration
+        # Invoke auto reload
+        if defined?(::Rails) && ::Rails.configuration.reloading_enabled?
+          puts "Reloading..."
+          ::Rails.autoloaders.main.reload
+        end
       else
+        # This is the first spec run
         cached_config.record_configuration(&rspec_configuration)
       end
     end

--- a/lib/rspec/daemon.rb
+++ b/lib/rspec/daemon.rb
@@ -72,6 +72,7 @@ module RSpec
 
     def rspec_configuration
       proc do
+        ENV['RSPEC_DAEMON'] = "1"
         if File.exist? "spec/rails_helper.rb"
           require "rails_helper"
         end


### PR DESCRIPTION
Closes #10.

Reload Rails application code on very run by calling `Rails.autoloaders.main.reload`. As described in README, configuration on the user side is required.

I strongly believe this makes rspec-daemon super useful.