### PR TITLE
Compatibility update for rspec-daemon with Rails < 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ if Rails.env.test? && ENV['RSPEC_DAEMON']
 end
 ```
 
+For Rails earlier than 7.0
+
+```
+if Rails.env.test? && ENV['RSPEC_DAEMON']
+  Rails.configuration.cache_classes = true
+end
+```
+
 If autoreloading is not configured, you'd need to restart `rspec-daemon` every time you change code under `app/`.
 Spec code (under `spec/`) will be always reloaded regardless of this setting.
 

--- a/lib/rspec/daemon.rb
+++ b/lib/rspec/daemon.rb
@@ -66,8 +66,8 @@ module RSpec
       if cached_config.has_recorded_config?
         # Reload configuration from the first time
         cached_config.replay_configuration
-        # Invoke auto reload
-        if defined?(::Rails) && ::Rails.configuration.reloading_enabled?
+        # Invoke auto reload (if Rails is in Zeitwerk mode and autoloading is enabled)
+        if defined?(::Rails) && Rails.respond_to?(:autoloaders) && !::Rails.configuration.cache_classes?
           puts "Reloading..."
           ::Rails.autoloaders.main.reload
         end


### PR DESCRIPTION
This pull request addresses the current limitation of rspec-daemon, which is only compatible with Rails 7.1. 
The proposed changes enable rspec-daemon to work with Rails versions 7.0 and earlier by utilizing the cache_classes configuration.

ref: https://github.com/rails/rails/pull/44870