### PR TITLE
Fix: Rails top-level calling and cache_classes loading method

### DIFF
--- a/lib/rspec/daemon.rb
+++ b/lib/rspec/daemon.rb
@@ -67,7 +67,7 @@ module RSpec
         # Reload configuration from the first time
         cached_config.replay_configuration
         # Invoke auto reload (if Rails is in Zeitwerk mode and autoloading is enabled)
-        if defined?(::Rails) && Rails.respond_to?(:autoloaders) && !::Rails.configuration.cache_classes?
+        if defined?(::Rails) && ::Rails.respond_to?(:autoloaders) && !::Rails.configuration.cache_classes
           puts "Reloading..."
           ::Rails.autoloaders.main.reload
         end


### PR DESCRIPTION
Hi there,

Thanks for this awesome Gem. Really useful!

I've tweaked a couple of things related to the reload conditions:
1. Moved the autoloader check to the top level.
2. Changed how we verify cache_classes settings.

If anything seems off, just let me know.